### PR TITLE
Set USPS Route lookup GM_xml_httpRequest to anonymous

### DIFF
--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -25,7 +25,7 @@
 /* global WazeWrap */
 /* global localStorage */
 
-const UPDATE_MESSAGE = 'Fix for new USPS route lookup tool restrictions.';
+const UPDATE_MESSAGE = 'Fix for cross-domain restrictions on USPS route lookup tool.';
 const SETTINGS_STORE_NAME = 'wme_us_government_boundaries';
 const ZIPS_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/4/';
 const COUNTIES_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/State_County/MapServer/1/';

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -426,7 +426,7 @@ function fetchUspsRoutesFeatures() {
     _$getRoutesButton.attr('disabled', 'true').css({ color: '#888' });
     _$uspsResultsDiv.empty().append('<i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>');
     _uspsRoutesLayer.removeAllFeatures();
-    GM_xmlhttpRequest({ url, onload: processUspsRoutesResponse });
+    GM_xmlhttpRequest({ url, onload: processUspsRoutesResponse, anonymous: true });
 }
 
 function fetchBoundaries() {

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -25,7 +25,7 @@
 /* global WazeWrap */
 /* global localStorage */
 
-const UPDATE_MESSAGE = 'Click the zip code in the map header to see USPS city recommendations.';
+const UPDATE_MESSAGE = 'Fix for new USPS route lookup tool restrictions.';
 const SETTINGS_STORE_NAME = 'wme_us_government_boundaries';
 const ZIPS_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/4/';
 const COUNTIES_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/State_County/MapServer/1/';


### PR DESCRIPTION
USPS appears to have implemented cross-domain restrictions on the EDDM server, based on the following being returned instead of the expected JSON:
`<html><head><title>ArcGIS Server Error</title><style><!--H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}A.name {color : black;}HR {color : #525D76;}--></style> </head><body><h1>Error occurred while processing request</h1><HR size="1" noshade="noshade"><p><b>Type:</b> Status Report</p><p><b>Message:</b> <u>Access to the requested resource has been denied</u></p><p><b>Description:</b> <u>http.403:Access to the requested resource has been denied</u></p><HR size="1" noshade="noshade"><h3>ArcGIS Server</h3></body></html>`

When the exact same request URL is opened directly in the browser, the JSON is returned as expected; therefore sending the request anonymously returns the expected JSON.