### PR TITLE
Add zip city lookup link to routes returned

### DIFF
--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -25,7 +25,7 @@
 /* global WazeWrap */
 /* global localStorage */
 
-const UPDATE_MESSAGE = 'Fix for new USPS route lookup tool restrictions.';
+const UPDATE_MESSAGE = 'Fix for cross-domain restrictions on USPS route lookup tool.';
 const SETTINGS_STORE_NAME = 'wme_us_government_boundaries';
 const ZIPS_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/4/';
 const COUNTIES_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/State_County/MapServer/1/';

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name            WME US Government Boundaries (beta)
+// @name            WME US Government Boundaries
 // @namespace       https://greasyfork.org/users/45389
 // @version         2019.07.04.001
 // @description     Adds a layer to display US (federal, state, and/or local) boundaries.

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name            WME US Government Boundaries
 // @namespace       https://greasyfork.org/users/45389
-// @version         2019.11.01.001
+// @version         2019.11.02.001
 // @description     Adds a layer to display US (federal, state, and/or local) boundaries.
 // @author          MapOMatic
 // @include         /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/
@@ -25,7 +25,7 @@
 /* global WazeWrap */
 /* global localStorage */
 
-const UPDATE_MESSAGE = '<ul><li>Add USPS city names lookup to USPS Routes results.</li><li>Fix display of ZIP codes with leading zeros.</li></ul>';
+const UPDATE_MESSAGE = '<ul><li>New: Click on USPS routes results to view alternate city names and city names to avoid for each ZIP code.</li><li>Fix display of ZIP codes with leading zeros.</li></ul>';
 const SETTINGS_STORE_NAME = 'wme_us_government_boundaries';
 const ZIPS_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/4/';
 const COUNTIES_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/State_County/MapServer/1/';

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -426,7 +426,7 @@ function fetchUspsRoutesFeatures() {
     _$getRoutesButton.attr('disabled', 'true').css({ color: '#888' });
     _$uspsResultsDiv.empty().append('<i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>');
     _uspsRoutesLayer.removeAllFeatures();
-    GM_xmlhttpRequest({ url, onload: processUspsRoutesResponse });
+    GM_xmlhttpRequest({ url, onload: processUspsRoutesResponse, anonymous: true });
 }
 
 function fetchBoundaries() {

--- a/WME US Government Boundaries.js
+++ b/WME US Government Boundaries.js
@@ -25,7 +25,7 @@
 /* global WazeWrap */
 /* global localStorage */
 
-const UPDATE_MESSAGE = 'Click the zip code in the map header to see USPS city recommendations.';
+const UPDATE_MESSAGE = 'Fix for new USPS route lookup tool restrictions.';
 const SETTINGS_STORE_NAME = 'wme_us_government_boundaries';
 const ZIPS_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/4/';
 const COUNTIES_LAYER_URL = 'https://tigerweb.geo.census.gov/arcgis/rest/services/Census2010/State_County/MapServer/1/';


### PR DESCRIPTION
Makes the cities/zips returned by USPS Routes into clickable links to return all city names (uses same function as existing city lookup in Zip Codes layer)